### PR TITLE
Switch glob importing strategy to avoid error

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "plugins": ["import-glob"]
+}

--- a/gulpfile.js/tasks/js.js
+++ b/gulpfile.js/tasks/js.js
@@ -1,7 +1,6 @@
 var gulp = require('gulp');
 var rollup = require('gulp-better-rollup');
 var babel = require('rollup-plugin-babel');
-const globImport = require('rollup-plugin-glob-import');
 const nodeResolve = require('@rollup/plugin-node-resolve');
 const commonjs = require('rollup-plugin-commonjs');
 
@@ -16,7 +15,7 @@ gulp.task('js', () => {
     .pipe(
       rollup(
         {
-          plugins: [babel(), globImport(), nodeResolve(), commonjs()]
+          plugins: [babel(), nodeResolve(), commonjs()]
         },
         {
           format: 'iife'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1304,6 +1304,16 @@
         "babel-runtime": "^6.22.0"
       }
     },
+    "babel-plugin-import-glob": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-import-glob/-/babel-plugin-import-glob-2.0.0.tgz",
+      "integrity": "sha1-gONICXMohcW8uHY3RMNM3bNxY8o=",
+      "requires": {
+        "glob": "^7.0.0",
+        "identifierfy": "^1.1.0",
+        "minimatch-capture": "^1.1.0"
+      }
+    },
     "babel-runtime": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
@@ -1384,8 +1394,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -1503,7 +1512,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2124,8 +2132,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -4220,8 +4227,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "1.2.9",
@@ -4933,7 +4939,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
       "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -5616,6 +5621,15 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "identifierfy": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/identifierfy/-/identifierfy-1.1.1.tgz",
+      "integrity": "sha1-j5Y2UK+jautC8v8O0V8pX/BAr/A=",
+      "requires": {
+        "babel-runtime": "^6.3.19",
+        "esutils": "^2.0.2"
+      }
+    },
     "iframe-resizer": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/iframe-resizer/-/iframe-resizer-4.2.8.tgz",
@@ -5692,7 +5706,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -5701,8 +5714,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
       "version": "1.3.5",
@@ -7068,9 +7080,16 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimatch-capture": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/minimatch-capture/-/minimatch-capture-1.1.0.tgz",
+      "integrity": "sha1-1sjCrNupLcL2aSHYAH7Q5CsvmFU=",
+      "requires": {
+        "minimatch": "^3.0.4"
       }
     },
     "minimist": {
@@ -7646,7 +7665,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -7905,8 +7923,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -9138,16 +9155,6 @@
         "magic-string": "^0.25.2",
         "resolve": "^1.11.0",
         "rollup-pluginutils": "^2.8.1"
-      }
-    },
-    "rollup-plugin-glob-import": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-glob-import/-/rollup-plugin-glob-import-0.4.4.tgz",
-      "integrity": "sha512-Cv+CyorfO7QcRZyG94AcdL8huNf5KByXgUKGvYs0b/sC88tEOHdXcDIIb3bc80bTLWwfOWrPqtfC6Cv/SFEg9A==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.1.4",
-        "rollup-pluginutils": "^2.8.2"
       }
     },
     "rollup-pluginutils": {
@@ -12051,8 +12058,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "require-dir": "^1.2.0",
     "rollup": "^1.26.3",
     "rollup-plugin-babel": "^4.3.3",
-    "rollup-plugin-glob-import": "^0.4.4",
     "slug": "^1.1.0",
     "stylelint": "^9.10.1",
     "stylelint-config-cloudfour-suit": "^2.0.0"
@@ -54,6 +53,7 @@
   "dependencies": {
     "@cloudfour/eslint-config": "^1.0.0",
     "@rollup/plugin-node-resolve": "^6.0.0",
+    "babel-plugin-import-glob": "^2.0.0",
     "iframe-resizer": "^4.2.8",
     "rollup-plugin-commonjs": "^10.1.0"
   }

--- a/src/scripts/toolkit.js
+++ b/src/scripts/toolkit.js
@@ -1,2 +1,2 @@
 // eslint-disable-next-line no-unused-vars
-import * as patterns from '../patterns/**/*.js';
+import '../patterns/**/*.js';


### PR DESCRIPTION
Switch from using a rollup plugin to a babel plugin

This resolves an odd error I was getting when saving JS files.

However it makes it harder to access exports.

We may still want to think more about how the toolkit imports files.

Maybe we leave it like this for now but expect end users are likely to modify it?

Regardless, I think this is a step in the right direction since the errors were crashing the app.

Fixes #27 