### PR TITLE
Add chance shortcode

### DIFF
--- a/helpers/shortcode/chance.js
+++ b/helpers/shortcode/chance.js
@@ -1,0 +1,22 @@
+const chance = require('chance').Chance();
+
+/**
+ * Generate random content via [Chance.js](http://chancejs.com).
+ *
+ * @param {String} method - Chance method to use.
+ * @param {Object|String} [options] - Additional options to pass to the method.
+ * May be an object or a JSON-formatted string.
+ * @return {*}
+ * @see {@link http://chancejs.com|Chance.js}
+ */
+module.exports = (method, options) => {
+  if (typeof chance[method] !== 'function') {
+    throw new TypeError(`The "chance" shortcode does not support "${method}"`);
+  }
+
+  if (typeof options === 'string') {
+    options = JSON.parse(options);
+  }
+
+  return chance[method](options);
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1843,6 +1843,11 @@
         }
       }
     },
+    "chance": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chance/-/chance-1.1.4.tgz",
+      "integrity": "sha512-pXPDSu3knKlb6H7ahQfpq//J9mSOxYK8SMtp8MV/nRJh8aLRDIl0ipLH8At8+nVogVwtvPZzyIzY/EbcY/cLuQ=="
+    },
     "character-entities": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.3.tgz",
@@ -4251,8 +4256,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4276,15 +4280,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4301,22 +4303,19 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4447,8 +4446,7 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4462,7 +4460,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4479,7 +4476,6 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4488,15 +4484,13 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4517,7 +4511,6 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4606,8 +4599,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4621,7 +4613,6 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4717,8 +4708,7 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4760,7 +4750,6 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4782,7 +4771,6 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4831,15 +4819,13 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@cloudfour/eslint-config": "^1.0.0",
     "@rollup/plugin-node-resolve": "^6.0.0",
     "babel-plugin-import-glob": "^2.0.0",
+    "chance": "^1.1.4",
     "iframe-resizer": "^4.2.8",
     "rollup-plugin-commonjs": "^10.1.0"
   }

--- a/src/prototypes/prototype-example/index.hbs
+++ b/src/prototypes/prototype-example/index.hbs
@@ -5,7 +5,7 @@ labels:
 - approved
 - patternready
 - archived
-notes: 
+notes:
   This is an example prototype showing every potential label.
 ---
 
@@ -24,9 +24,25 @@ notes:
 </p>
 
 <p>
-  Here you can see we're using 
-  <a href="/patterns/pattern-example/">a pattern</a> 
+  Here you can see we're using
+  <a href="/patterns/pattern-example/">a pattern</a>
   in our prototype, with its associated styles and JavaScript interactions:
 </p>
 
 {{>pattern-example}}
+
+<p>
+  Here's an example of some dummy content…
+</p>
+
+<p>
+  A paragraph: {{chance 'paragraph' '{ "sentences": 2 }'}}
+</p>
+
+<p>
+  A name: {{chance 'name'}}
+</p>
+
+<p>
+  A color: {{chance 'color' '{ "format": "hex" }'}}
+</p>


### PR DESCRIPTION
Exposes the [Chance.js](https://chancejs.com/index.html) library to prototypes via a `chance` universal shortcode.

This is similar to our [`random` helper](https://github.com/cloudfour/core-hbs-helpers/blob/master/lib/random.js) but with a number of important differences:

- Because it is a [universal shortcode](https://www.11ty.dev/docs/shortcodes/), it may be used in any format of template.
- It requires a method to be specified, which simplifies a lot of the function's argument parsing.
- It allows an object of options _or_ a JSON-formatted string of options, making it easier to customize output across various templating languages.
- Its name more clearly reflects its lineage (less looking up the name of the library to find its documentation).
- As of this writing, it does not appear to be flagged by Eleventy for significantly affecting performance.

---

See #6