### PR TITLE
Add dummyImage shortcode

### DIFF
--- a/helpers/shortcode/dummy-image.js
+++ b/helpers/shortcode/dummy-image.js
@@ -15,7 +15,7 @@ function template({
   </svg>`;
 }
 
-function encode(rendered) {
+function svgSourceToDataUri(rendered) {
   // Thanks to: filamentgroup/directory-encoder
   const cleaned = rendered
     .replace(/[\n\r]/gim, '') // Strip newlines
@@ -51,5 +51,5 @@ module.exports = (width, height, text) => {
     text: typeof text === 'string' ? text : undefined
   };
 
-  return encode(template(options));
+  return svgSourceToDataUri(template(options));
 };

--- a/helpers/shortcode/dummy-image.js
+++ b/helpers/shortcode/dummy-image.js
@@ -1,0 +1,48 @@
+function template({
+  width,
+  height = width,
+  text = `${width}&#215;${height}`,
+  fontFamily = 'sans-serif',
+  fontWeight = 'bold',
+  fontSize = Math.floor(Math.min(width, height) * 0.2),
+  textAdjust = Math.floor(fontSize * 0.4),
+  bgColor = '#ddd',
+  textColor = 'rgba(0,0,0,0.5)'
+} = {}) {
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
+    <rect fill="${bgColor}" width="${width}" height="${height}"/>
+    <text fill="${textColor}" font-family="${fontFamily}" font-size="${fontSize}" dy="${textAdjust}" font-weight="${fontWeight}" x="50%" y="50%" text-anchor="middle">${text}</text>
+  </svg>`;
+}
+
+function encode(rendered) {
+  // Thanks to: filamentgroup/directory-encoder
+  const cleaned = rendered
+    .replace(/[\n\r]/gim, '') // Strip newlines
+    .replace(/\t/gim, ' ') // Replace tabs with strings
+    .replace(/'/gim, '\\i'); // Normalize quotes
+  const encoded = encodeURIComponent(cleaned)
+    .replace(/\(/g, '%28') // Encode brackets
+    .replace(/\)/g, '%29');
+  return 'data:image/svg+xml;charset=US-ASCII,' + encoded;
+}
+
+/**
+ * Return an inline SVG as a string suitable for including in an `<img>`
+ * element's `src` attribute.
+ *
+ * @param {Number} width
+ * @param {Number} [height] - Will default to the same number as width.
+ * @param {String} [text] - Will default to the width and height.
+ * @return {String}
+ * @todo Consider breaking this into a Sindre Sorhus-style micro library?
+ */
+module.exports = (width, height, text) => {
+  return encode(
+    template({
+      width,
+      height: typeof height === 'number' ? height : undefined, // In case of Handlebars options object
+      text: typeof text === 'string' ? text : undefined // In case of Handlebars options object
+    })
+  );
+};

--- a/helpers/shortcode/dummy-image.js
+++ b/helpers/shortcode/dummy-image.js
@@ -38,11 +38,18 @@ function encode(rendered) {
  * @todo Consider breaking this into a Sindre Sorhus-style micro library?
  */
 module.exports = (width, height, text) => {
-  return encode(
-    template({
-      width,
-      height: typeof height === 'number' ? height : undefined, // In case of Handlebars options object
-      text: typeof text === 'string' ? text : undefined // In case of Handlebars options object
-    })
-  );
+  /**
+   * In theory we would be able to pass this to our template function as
+   * simply `{ width, height, text }`, but if the template language is
+   * Handlebars, the last argument will always be an object containing template
+   * data. To avoid that along as a value for `height` or `text`, we do a type
+   * check on that argument first.
+   */
+  const options = {
+    width,
+    height: typeof height === 'number' ? height : undefined,
+    text: typeof text === 'string' ? text : undefined
+  };
+
+  return encode(template(options));
 };

--- a/src/prototypes/prototype-example/index.hbs
+++ b/src/prototypes/prototype-example/index.hbs
@@ -46,3 +46,7 @@ notes:
 <p>
   A color: {{chance 'color' '{ "format": "hex" }'}}
 </p>
+
+<p>
+  An image: <img src="{{dummyImage 200 100}}" alt="">
+</p>


### PR DESCRIPTION
This adds a simple `dummyImage` shortcode for prototyping. This is very similar to [our `dummyImgSrc` helper](https://github.com/cloudfour/core-hbs-helpers/blob/master/lib/dummyImgSrc.js), with a few differences:

- It has fewer options. Since this is part of the project boilerplate, I figure any default colors or other adjustments can be made directly to the helper.
- It does not bother stripping comments from the source when the source string never changes. (D'oh!)
- It has no dependencies.
- It is a [universal shortcode](https://www.11ty.dev/docs/shortcodes/), so it will work for any template language that Eleventy supports.

I've added an example to the prototype:

<img width="330" alt="Screen Shot 2019-12-27 at 3 11 08 PM" src="https://user-images.githubusercontent.com/69633/71535459-28662680-28bb-11ea-8dc3-168bc10723e8.png">

---

See #6 