### PR TITLE
Negate whitespace for code parent partials

### DIFF
--- a/src/_includes/layouts/pattern.hbs
+++ b/src/_includes/layouts/pattern.hbs
@@ -9,7 +9,7 @@ layout: layouts/pattern-library
 
   {{#each (sortCollection collections.patternExamples)}}
     {{#if (isExamplePath this.inputPath ../page.inputPath)}}
-      {{> layouts/pattern-example this}}
+      {{~> layouts/pattern-example this~}}
     {{/if}}
   {{/each}}
 </div>


### PR DESCRIPTION
Previously, code samples were sometimes oddly indented.

This is a problem that is unique to Handlebars. It even includes [a `compile` setting specifically for this problem](https://handlebarsjs.com/api-reference/compilation.html):

> `preventIndent`: By default, an indented partial-call causes the output of the whole partial being indented by the same amount. This can lead to unexpected behavior when the partial writes `pre`-tags. Setting this option to `true` will disable the auto-indent feature.

Unfortunately, there's no way to toggle that setting on the library itself, and Eleventy doesn't expose any straightforward method of passing arguments to the `compile` function.

A simpler solution is to make sure that whitespace is being negated for not just the code output, but the partials that are including that output. This seems to have resolved the problem.

<img width="464" alt="Screen Shot 2020-01-02 at 4 04 25 PM" src="https://user-images.githubusercontent.com/69633/71700661-192f1f00-2d7a-11ea-8669-9b6f447342f7.png">

If we encounter more quirks like this, we may want to consider switching to another template engine (Nunjucks, maybe?) for the style guide templates.

---

Fixes #15 