### PR TITLE
Simplify dummy image helper

### DIFF
--- a/helpers/shortcode/dummy-image.js
+++ b/helpers/shortcode/dummy-image.js
@@ -4,8 +4,25 @@ const simpleSvgPlaceholder = require('@cloudfour/simple-svg-placeholder');
  * Return an inline SVG as a string suitable for including in an `<img>`
  * element's `src` attribute.
  *
- * @param {Object} [options] - Settings for the simpleSvgPlaceholder function.
- * @see https://github.com/cloudfour/simple-svg-placeholder
+ * @param {Number} width
+ * @param {Number} [height] - Will default to the same number as width.
+ * @param {String} [text] - Will default to the width and height.
  * @return {String}
+ * @see https://github.com/cloudfour/simple-svg-placeholder
  */
-module.exports = options => simpleSvgPlaceholder(options.hash || {});
+module.exports = (width, height, text) => {
+  /**
+   * In theory we would be able to pass this to our template function as
+   * simply `{ width, height, text }`, but if the template language is
+   * Handlebars, the last argument will always be an object containing template
+   * data. To avoid that along as a value for `height` or `text`, we do a type
+   * check on that argument first.
+   */
+  const options = {
+    width,
+    height: typeof height === 'number' ? height : undefined,
+    text: typeof text === 'string' ? text : undefined
+  };
+
+  return simpleSvgPlaceholder(options);
+};

--- a/helpers/shortcode/dummy-image.js
+++ b/helpers/shortcode/dummy-image.js
@@ -1,55 +1,11 @@
-function template({
-  width,
-  height = width,
-  text = `${width}&#215;${height}`,
-  fontFamily = 'sans-serif',
-  fontWeight = 'bold',
-  fontSize = Math.floor(Math.min(width, height) * 0.2),
-  textAdjust = Math.floor(fontSize * 0.4),
-  bgColor = '#ddd',
-  textColor = 'rgba(0,0,0,0.5)'
-} = {}) {
-  return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
-    <rect fill="${bgColor}" width="${width}" height="${height}"/>
-    <text fill="${textColor}" font-family="${fontFamily}" font-size="${fontSize}" dy="${textAdjust}" font-weight="${fontWeight}" x="50%" y="50%" text-anchor="middle">${text}</text>
-  </svg>`;
-}
-
-function svgSourceToDataUri(rendered) {
-  // Thanks to: filamentgroup/directory-encoder
-  const cleaned = rendered
-    .replace(/[\n\r]/gim, '') // Strip newlines
-    .replace(/\t/gim, ' ') // Replace tabs with strings
-    .replace(/'/gim, '\\i'); // Normalize quotes
-  const encoded = encodeURIComponent(cleaned)
-    .replace(/\(/g, '%28') // Encode brackets
-    .replace(/\)/g, '%29');
-  return 'data:image/svg+xml;charset=US-ASCII,' + encoded;
-}
+const simpleSvgPlaceholder = require('@cloudfour/simple-svg-placeholder');
 
 /**
  * Return an inline SVG as a string suitable for including in an `<img>`
  * element's `src` attribute.
  *
- * @param {Number} width
- * @param {Number} [height] - Will default to the same number as width.
- * @param {String} [text] - Will default to the width and height.
+ * @param {Object} [options] - Settings for the simpleSvgPlaceholder function.
+ * @see https://github.com/cloudfour/simple-svg-placeholder
  * @return {String}
- * @todo Consider breaking this into a Sindre Sorhus-style micro library?
  */
-module.exports = (width, height, text) => {
-  /**
-   * In theory we would be able to pass this to our template function as
-   * simply `{ width, height, text }`, but if the template language is
-   * Handlebars, the last argument will always be an object containing template
-   * data. To avoid that along as a value for `height` or `text`, we do a type
-   * check on that argument first.
-   */
-  const options = {
-    width,
-    height: typeof height === 'number' ? height : undefined,
-    text: typeof text === 'string' ? text : undefined
-  };
-
-  return svgSourceToDataUri(template(options));
-};
+module.exports = options => simpleSvgPlaceholder(options.hash || {});

--- a/package-lock.json
+++ b/package-lock.json
@@ -464,6 +464,11 @@
         "eslint-plugin-unicorn": "^9.0.0"
       }
     },
+    "@cloudfour/simple-svg-placeholder": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@cloudfour/simple-svg-placeholder/-/simple-svg-placeholder-1.0.1.tgz",
+      "integrity": "sha512-ism0Ke1Wp7eN//Zqn0/ed61/qncZOF5ouu/WV1EgjjQD1/7v5DFvqZJImjKqcaF8nBhY8XeCZsXNqqX7LmdwZQ=="
+    },
     "@gulp-sourcemaps/identity-map": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/identity-map/-/identity-map-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "homepage": "https://github.com/cloudfour/eleventy-patterns#readme",
   "dependencies": {
     "@cloudfour/eslint-config": "^1.0.0",
+    "@cloudfour/simple-svg-placeholder": "^1.0.1",
     "@rollup/plugin-node-resolve": "^6.0.0",
     "babel-plugin-import-glob": "^2.0.0",
     "chance": "^1.1.4",

--- a/src/prototypes/prototype-example/index.hbs
+++ b/src/prototypes/prototype-example/index.hbs
@@ -48,5 +48,5 @@ notes:
 </p>
 
 <p>
-  An image: <img src="{{dummyImage 200 100}}" alt="">
+  An image: <img src="{{dummyImage width=200 height=100 text='Hello world!'}}" alt="">
 </p>

--- a/src/prototypes/prototype-example/index.hbs
+++ b/src/prototypes/prototype-example/index.hbs
@@ -48,5 +48,5 @@ notes:
 </p>
 
 <p>
-  An image: <img src="{{dummyImage width=200 height=100 text='Hello world!'}}" alt="">
+  An image: <img src="{{dummyImage 200 100}}" alt="">
 </p>


### PR DESCRIPTION
Replaces the custom dummy image logic with [the new npm package](https://github.com/cloudfour/simple-svg-placeholder) and replaces the `@todo` asking if it should be separate with a link to that.